### PR TITLE
Docker-based Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,39 @@
 ---
 
-language: python
-python: "2.7"
+# Provide docker for testing other distros
+sudo: required
+services:
+  - docker
 
-# Don't use the new container infrastructure
-sudo: require
+env:
+  - distribution: ubuntu
+    version: 14.04
+    init: /sbin/init
+    run_opts: ""
+
+before_install:
+  - docker pull ${distribution}:${version}
+  - docker build --rm=true --file=tests/Dockerfile.${distribution}-${version} --tag=${distribution}-${version}:ansible tests
 
 install:
-  # Install pip
-  - sudo aptitude install python-pip
-
-  # Install ansible
-  - pip install ansible
-
-  # Check ansible version
-  - ansible --version
-
-  # Create ansible.cfg with correct roles_path
-  - printf '[defaults]\nroles_path=../' >ansible.cfg
+  - container_id=$(mktemp) # track container
+  - docker run -d --volume="${PWD}":/etc/ansible/roles/icecast:ro ${run_opts} ${distribution}-${version}:ansible "${init}" > "${container_id}"
+  - docker ps -a
 
 script:
   # Basic role syntax check
-  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+  - docker exec --tty "$(< $container_id)" env TERM=xterm ansible-playbook /etc/ansible/roles/icecast/tests/test.yml --syntax-check
   # Test role
-  - ansible-playbook tests/test.yml -i tests/inventory
+  - docker exec --tty "$(< $container_id)" env TERM=xterm ansible-playbook /etc/ansible/roles/icecast/tests/test.yml -vvvv
   # Check idempotence of role
   - >
-    ansible-playbook tests/test.yml -i tests/inventory
+    docker exec --tty "$(< $container_id)" env TERM=xterm ansible-playbook /etc/ansible/roles/icecast/tests/test.yml
     | grep -q 'changed=0.*failed=0'
     && (echo 'Idempotence test: pass' && exit 0)
     || (echo 'Idempotence test: fail' && exit 1)
+
+after_script:
+  - docker stop "$(< $container_id)"
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/files/icecast2.init
+++ b/files/icecast2.init
@@ -1,0 +1,84 @@
+#! /bin/sh
+### BEGIN INIT INFO
+# Provides:          icecast2
+# Required-Start:    $remote_fs $network
+# Required-Stop:     $remote_fs
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Starts the icecast audio streaming server daemon
+### END INIT INFO
+#
+# icecast2
+#
+#		Written by Miquel van Smoorenburg <miquels@cistron.nl>.
+#		Modified for Debian 
+#		by Ian Murdock <imurdock@gnu.ai.mit.edu>.
+#
+#		Further modified by Keegan Quinn <ice@thebasement.org>
+#		for use with Icecast 2
+#
+
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+DAEMON=/usr/bin/icecast2
+NAME=icecast2
+DESC=icecast2
+
+test -x $DAEMON || exit 0
+
+. /lib/lsb/init-functions
+
+# Defaults
+CONFIGFILE="/etc/icecast2/icecast.xml"
+CONFIGDEFAULTFILE="/etc/default/icecast2"
+PIDFILE=/var/run/icecast2/icecast2.pid
+USERID=icecast2
+GROUPID=icecast
+ENABLE="false"
+
+# Reads config file (will override defaults above)
+[ -r "$CONFIGDEFAULTFILE" ] && . $CONFIGDEFAULTFILE
+
+if [ "$ENABLE" != "true" ]; then
+	echo "$NAME daemon disabled - read $CONFIGDEFAULTFILE."
+	exit 0
+fi
+
+set -e
+
+case "$1" in
+  start)
+	echo -n "Starting $DESC: "
+	start-stop-daemon --start --quiet --oknodo --chuid $USERID:$GROUPID \
+		--pidfile $PIDFILE --startas $DAEMON -- -b -c $CONFIGFILE
+	echo "$NAME."
+	;;
+  stop)
+	echo -n "Stopping $DESC: "
+	# Send TERM after 5 seconds, wait at most 30 seconds.
+	start-stop-daemon --stop --oknodo --retry TERM/5/0/30 --quiet \
+		--pidfile $PIDFILE
+	echo "$NAME."
+	;;
+  reload|force-reload)
+	echo "Reloading $DESC configuration files."
+	start-stop-daemon --stop --signal 1 --quiet --pidfile $PIDFILE
+	;;
+  restart)
+	echo -n "Restarting $DESC: "
+	# Send TERM after 5 seconds, wait at most 30 seconds.
+	start-stop-daemon --stop --oknodo --retry TERM/5/0/30 --quiet \
+		--pidfile $PIDFILE
+	start-stop-daemon --start --quiet --chuid $USERID:$GROUPID \
+		--pidfile $PIDFILE --startas $DAEMON -- -b -c $CONFIGFILE
+	echo "$NAME."
+	;;
+  status)
+	start-stop-daemon --status --pidfile $PIDFILE
+	;;
+  *)
+	echo "Usage: $0 {start|stop|restart|reload|force-reload}" >&2
+	exit 1
+	;;
+esac
+
+exit 0

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,8 +12,6 @@ galaxy_info:
 
   platforms:
     - name: Debian
-      versions: all
-    - name: Ubuntu
-      versions: all
+      versions: jessie
 
   galaxy_tags: []

--- a/tasks/config-Debian.yml
+++ b/tasks/config-Debian.yml
@@ -6,3 +6,21 @@
     regexp: "^ENABLE="
     line: "ENABLE=true"
     state: present
+
+- name: Ensure PID directory exists
+  file:
+    path: /var/run/icecast2
+    owner: icecast2
+    group: icecast
+    mode: 0755
+    state: directory
+  when: ansible_distribution == "Ubuntu"
+
+- name: Provide custom init script
+  copy:
+    src: icecast2.init
+    dest: /etc/init.d/icecast2
+    owner: root
+    group: root
+    mode: 0755
+  when: ansible_distribution == "Ubuntu"

--- a/templates/icecast.xml.j2
+++ b/templates/icecast.xml.j2
@@ -68,6 +68,9 @@
     <webroot>/usr/share/icecast2/web</webroot>
     <adminroot>/usr/share/icecast2/admin</adminroot>
     <alias source="/" destination="/status.xsl"/>
+{% if ansible_distribution == "Ubuntu" %}
+    <pidfile>/var/run/icecast2/icecast2.pid</pidfile>
+{% endif %}
   </paths>
 
 </icecast>

--- a/tests/Dockerfile.ubuntu-14.04
+++ b/tests/Dockerfile.ubuntu-14.04
@@ -1,0 +1,11 @@
+FROM ubuntu:14.04
+RUN apt-get update
+
+# Install Ansible
+RUN apt-get install -y software-properties-common git
+RUN apt-add-repository -y ppa:ansible/ansible
+RUN apt-get update
+RUN apt-get install -y ansible
+
+# Install Ansible inventory file
+RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,1 +1,0 @@
-localhost

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,6 +1,5 @@
 ---
 
 - hosts: localhost
-  become: yes
   roles:
-    - icecast2
+    - icecast


### PR DESCRIPTION
Use Docker to host the tests on Travis to improve reproducibility on development machines when trying to identify _why_ things fail.

In this case, Ubuntu was failing due to a bad init script.
