### PR TITLE
Only apply init script fix to older Ubuntu versions

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,6 +12,8 @@ galaxy_info:
 
   platforms:
     - name: Debian
-      versions: jessie
+      versions: all
+    - name: Ubuntu
+      versions: all
 
   galaxy_tags: []

--- a/tasks/config-Debian.yml
+++ b/tasks/config-Debian.yml
@@ -6,21 +6,3 @@
     regexp: "^ENABLE="
     line: "ENABLE=true"
     state: present
-
-- name: Ensure PID directory exists
-  file:
-    path: /var/run/icecast2
-    owner: icecast2
-    group: icecast
-    mode: 0755
-    state: directory
-  when: ansible_distribution == "Ubuntu"
-
-- name: Provide custom init script
-  copy:
-    src: icecast2.init
-    dest: /etc/init.d/icecast2
-    owner: root
-    group: root
-    mode: 0755
-  when: ansible_distribution == "Ubuntu"

--- a/tasks/fix-init.yml
+++ b/tasks/fix-init.yml
@@ -1,0 +1,20 @@
+---
+
+# Workaround for bad init script that prevents 'service icecast2
+# start' from being run idempotently.
+
+- name: Ensure PID directory exists
+  file:
+    path: /var/run/icecast2
+    owner: icecast2
+    group: icecast
+    mode: 0755
+    state: directory
+
+- name: Provide custom init script
+  copy:
+    src: icecast2.init
+    dest: /etc/init.d/icecast2
+    owner: root
+    group: root
+    mode: 0755

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,15 @@
 - include: setup-Debian.yml
   when: ansible_os_family == 'Debian'
 
+- set_fact:
+    icecast_require_init_fix: true
+  # Later versions move to systemd
+  when: ansible_distribution == 'Ubuntu' and
+        ansible_distribution_major_version|version_compare('14', '<=')
+
+- include: fix-init.yml
+  when: icecast_require_init_fix
+
 - name: Provide an mp3 for a silent fallback
   copy:
     src: silence.mp3

--- a/templates/icecast.xml.j2
+++ b/templates/icecast.xml.j2
@@ -68,7 +68,7 @@
     <webroot>/usr/share/icecast2/web</webroot>
     <adminroot>/usr/share/icecast2/admin</adminroot>
     <alias source="/" destination="/status.xsl"/>
-{% if ansible_distribution == "Ubuntu" %}
+{% if icecast_require_init_fix %}
     <pidfile>/var/run/icecast2/icecast2.pid</pidfile>
 {% endif %}
   </paths>

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,3 +6,6 @@ icecast_log_levels:
   info: 3
   warn: 2
   error: 1
+
+# Most environments should not require the custom init script.
+icecast_require_init_fix: false


### PR DESCRIPTION
The fix is only relevant in the pre-systemd world. From testing on Debian Jessie, everything seems to function as expected. It may not be worth pushing the fix upstream, and instead recommended the use of newer target hosts.
